### PR TITLE
Fix Dockerfile casing warnings

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,35 +1,35 @@
 # syntax=docker/dockerfile:1
 
-FROM composer:lts as prod-deps
+FROM composer:lts AS prod-deps
 WORKDIR /app
 RUN --mount=type=bind,source=./composer.json,target=composer.json \
     --mount=type=bind,source=./composer.lock,target=composer.lock \
     --mount=type=cache,target=/tmp/cache \
     composer install --no-dev --no-interaction
 
-FROM composer:lts as dev-deps
+FROM composer:lts AS dev-deps
 WORKDIR /app
 RUN --mount=type=bind,source=./composer.json,target=composer.json \
     --mount=type=bind,source=./composer.lock,target=composer.lock \
     --mount=type=cache,target=/tmp/cache \
     composer install --no-interaction
 
-FROM php:8.2-apache as base
+FROM php:8.2-apache AS base
 RUN docker-php-ext-install pdo pdo_mysql
 RUN a2enmod rewrite
 COPY ./src /var/www/html
 
-FROM base as development
+FROM base AS development
 COPY ./tests /var/www/html/tests
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY --from=dev-deps app/vendor/ /var/www/html/vendor
 
 #* Run tests when building
-# FROM development as test
+# FROM development AS test
 # WORKDIR /var/www/html
 # RUN ./vendor/bin/phpunit tests/HelloWorldTest.php
 
-FROM base as final
+FROM base AS final
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY --from=prod-deps app/vendor/ /var/www/html/vendor
 USER www-data


### PR DESCRIPTION
Resolve casing mismatch warnings in the Dockerfile by updating the keywords to use consistent uppercase formatting.