### PR TITLE
fix(docker-database): improve behavior so that initialization scripts are executed every time a file changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1
 
+#* Create a database stage for setting up the database.
+FROM mariadb:lts AS database
+COPY ./docker/database/start-scripts/ /docker-entrypoint-initdb.d/
+
 #* Create a prod stage for installing app dependencies defined in Composer.
 FROM composer:lts AS prod-deps
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
   server:
     build:
       context: .
-      dockerfile: ./docker/server/Dockerfile
       target: development
     ports:
       - 8000:80
@@ -34,7 +33,9 @@ services:
           target: /var/www/html
 
   database:
-    image: mariadb:latest
+    build:
+      context: .
+      target: database
     restart: always
     user: root
     secrets:
@@ -42,8 +43,14 @@ services:
     networks:
       - app-network
     volumes:
-      # - database-data:/var/lib/mysql
       - ./docker/database/start-scripts/:/docker-entrypoint-initdb.d/
+      #! Necessary for production ↓
+      # - database-data:/var/lib/mysql
+    #* This will store the database in memory, so it will be lost when the container is stopped
+    #* Allows start-scripts to be run on each container start
+    #! Necessary for development, remove in production ↓
+    tmpfs:
+      - /var/lib/mysql
     ports:
       - "3306:3306"
     environment:
@@ -61,6 +68,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    develop:
+      watch:
+        - action: rebuild
+          path: ./docker/database
 
   phpmyadmin:
     image: phpmyadmin:latest
@@ -69,7 +80,8 @@ services:
     networks:
       - app-network
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     environment:
       PMA_HOST: database
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,13 +45,13 @@ services:
     #! Necessary for production ↓
     # volumes:
     #  - database-data:/var/lib/mysql
+    #! Necessary for development, remove in production ↓
     #* This will store the database in memory, so it will be lost when the container is stopped
     #* Allows start-scripts to be run on each container start
-    #! Necessary for development, remove in production ↓
     tmpfs:
       - /var/lib/mysql
     ports:
-      - "3306:3306"
+      - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD_FILE: /run/secrets/database-password
       MYSQL_DATABASE: urbantree
@@ -75,7 +75,7 @@ services:
   phpmyadmin:
     image: phpmyadmin:latest
     ports:
-      - "8080:80"
+      - 8080:80
     networks:
       - app-network
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - DB_HOST=database
       - DB_NAME=urbantree
       - DB_USER=root
-      - PASSWORD_FILE_PATH=/run/secrets/database-password
+      - DB_PASS_FILE_PATH=/run/secrets/database-password
       - LOG_FILE_PATH=/var/www/html/storage/logs/app.log
     develop:
       watch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,9 @@ services:
       - database-password
     networks:
       - app-network
-    volumes:
-      - ./docker/database/start-scripts/:/docker-entrypoint-initdb.d/
-      #! Necessary for production ↓
-      # - database-data:/var/lib/mysql
+    #! Necessary for production ↓
+    # volumes:
+    #  - database-data:/var/lib/mysql
     #* This will store the database in memory, so it will be lost when the container is stopped
     #* Allows start-scripts to be run on each container start
     #! Necessary for development, remove in production ↓

--- a/src/app/Core/Database.php
+++ b/src/app/Core/Database.php
@@ -13,14 +13,13 @@ class Database
     {
         if (!self::$instance) {
             try {
-                $password_file_path = getenv('PASSWORD_FILE_PATH');
-
                 // Read the password from the file
-                $db_pass = trim(file_get_contents($password_file_path));
+                $db_pass = trim(file_get_contents(getenv('DB_PASS_FILE_PATH')));
 
                 self::$instance = new PDO(
                     "mysql:host=" . getenv('DB_HOST') . ";dbname=" . getenv('DB_NAME'),
-                    getenv('DB_USER'), $db_pass
+                    getenv('DB_USER'),
+                    $db_pass
                 );
                 self::$instance->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
             } catch (PDOException $e) {


### PR DESCRIPTION
Ensure that start-scripts run on each restart of the database container by creating a dedicated database stage in the Dockerfile. Adjust the database service configuration to build from this stage and utilize a temporary filesystem for development.

The database service will restart when detects changes on any file of `docker\database\start-scripts`, allowing scripts to be executed.
Switching between branches was annoying because we need to delete the service, while now it is no longer necessary, because it will update automatically if it detects changes.