### PR TITLE
revert(TaskType): restore created_at assignment in task creation

### DIFF
--- a/src/app/Models/TaskType.php
+++ b/src/app/Models/TaskType.php
@@ -16,7 +16,7 @@ class TaskType extends BaseModel
         $task = new self();
         $task->id = $data['id'];
         $task->name = $data['name'];
-        // $task->created_at = $data['created_at'];
+        $task->created_at = $data['created_at'];
 
         return $task;
     }


### PR DESCRIPTION
Revert the previous change that removed the assignment of `created_at` during task creation to ensure the timestamp is correctly set.