### PR TITLE
feat(base-model): update method signatures to allow nullable return types

### DIFF
--- a/src/app/Models/BaseModel.php
+++ b/src/app/Models/BaseModel.php
@@ -335,12 +335,12 @@ abstract class BaseModel
     abstract protected static function mapDataToModel($data);
 
     //* Getters and Setters
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?string
     {
         return $this->created_at;
     }

--- a/src/app/Models/BaseModel.php
+++ b/src/app/Models/BaseModel.php
@@ -94,7 +94,7 @@ abstract class BaseModel
     }
 
     // Count the number of records in the table
-    public static function count($conditions = [])
+    public static function count($conditions = []): ?int
     {
         $query = "SELECT COUNT(*) as count FROM " . static::getTableName();
         $params = [];
@@ -160,7 +160,7 @@ abstract class BaseModel
     }
 
     // Fetch all records from the table
-    public static function findAll($filters = [], $includeDeleted = false)
+    public static function findAll($filters = [], $includeDeleted = false): array
     {
         $query = "SELECT * FROM " . static::getTableName();
         $params = [];
@@ -183,7 +183,7 @@ abstract class BaseModel
     }
 
     // Find a record by a specific column
-    public static function findBy($conditions, $single = false)
+    public static function findBy($conditions, $single = false): array
     {
         $table = static::getTableName();
 
@@ -215,7 +215,7 @@ abstract class BaseModel
     }
 
     // Fetch all soft deleted records
-    public static function findSoftDeleted()
+    public static function findSoftDeleted(): array
     {
         if (! static::hasSoftDelete())
             return [];
@@ -271,7 +271,7 @@ abstract class BaseModel
     }
 
     // Paginate the records in the table
-    public static function paginate($page = 1, $perPage = 10, $conditions = [])
+    public static function paginate($page = 1, $perPage = 10, $conditions = []): ?array
     {
         $offset = ($page - 1) * $perPage;
         $query = "SELECT * FROM " . static::getTableName();
@@ -331,7 +331,7 @@ abstract class BaseModel
     }
 
     //* Abstract methods to enforce subclass implementation
-    abstract protected static function getTableName();
+    abstract protected static function getTableName(): string;
     abstract protected static function mapDataToModel($data);
 
     //* Getters and Setters

--- a/src/app/Models/BaseModel.php
+++ b/src/app/Models/BaseModel.php
@@ -94,7 +94,7 @@ abstract class BaseModel
     }
 
     // Count the number of records in the table
-    public static function count($conditions = []): ?int
+    public static function count(array $conditions = []): ?int
     {
         $query = "SELECT COUNT(*) as count FROM " . static::getTableName();
         $params = [];
@@ -126,7 +126,7 @@ abstract class BaseModel
     }
 
     // Check if a record exists in the table
-    public static function exists($conditions = []): bool
+    public static function exists(array $conditions = []): bool
     {
         $query = "SELECT COUNT(*) as count FROM " . static::getTableName();
         $params = [];
@@ -145,7 +145,7 @@ abstract class BaseModel
     }
 
     // Find a record by its ID
-    public static function find($id)
+    public static function find(string $id): ?object
     {
         $table = static::getTableName();
 
@@ -160,7 +160,7 @@ abstract class BaseModel
     }
 
     // Fetch all records from the table
-    public static function findAll($filters = [], $includeDeleted = false): array
+    public static function findAll(array $filters = [], bool $includeDeleted = false): array
     {
         $query = "SELECT * FROM " . static::getTableName();
         $params = [];
@@ -183,7 +183,7 @@ abstract class BaseModel
     }
 
     // Find a record by a specific column
-    public static function findBy($conditions, $single = false): ?array
+    public static function findBy(array $conditions, bool $single = false): ?array
     {
         $table = static::getTableName();
 
@@ -228,7 +228,7 @@ abstract class BaseModel
     }
 
     // One-to-One relationship
-    public function hasOne($relatedModel, $foreignKey, $localKey = 'id'): ?object
+    public function hasOne(string $relatedModel, string $foreignKey, string $localKey = 'id'): ?object
     {
         $relatedTable = $relatedModel::getTableName();
         $localKeyValue = $this->{$localKey};
@@ -271,7 +271,7 @@ abstract class BaseModel
     }
 
     // Paginate the records in the table
-    public static function paginate($page = 1, $perPage = 10, $conditions = []): ?array
+    public static function paginate(int $page = 1, int $perPage = 10, array $conditions = []): ?array
     {
         $offset = ($page - 1) * $perPage;
         $query = "SELECT * FROM " . static::getTableName();
@@ -332,7 +332,7 @@ abstract class BaseModel
 
     //* Abstract methods to enforce subclass implementation
     abstract protected static function getTableName(): string;
-    abstract protected static function mapDataToModel($data): object;
+    abstract protected static function mapDataToModel(array $data): object;
 
     //* Getters and Setters
     public function getId(): ?int

--- a/src/app/Models/BaseModel.php
+++ b/src/app/Models/BaseModel.php
@@ -183,7 +183,7 @@ abstract class BaseModel
     }
 
     // Find a record by a specific column
-    public static function findBy($conditions, $single = false): array
+    public static function findBy($conditions, $single = false): ?array
     {
         $table = static::getTableName();
 
@@ -228,7 +228,7 @@ abstract class BaseModel
     }
 
     // One-to-One relationship
-    public function hasOne($relatedModel, $foreignKey, $localKey = 'id')
+    public function hasOne($relatedModel, $foreignKey, $localKey = 'id'): ?object
     {
         $relatedTable = $relatedModel::getTableName();
         $localKeyValue = $this->{$localKey};
@@ -332,7 +332,7 @@ abstract class BaseModel
 
     //* Abstract methods to enforce subclass implementation
     abstract protected static function getTableName(): string;
-    abstract protected static function mapDataToModel($data);
+    abstract protected static function mapDataToModel($data): object;
 
     //* Getters and Setters
     public function getId(): ?int

--- a/src/app/Models/Route.php
+++ b/src/app/Models/Route.php
@@ -24,7 +24,7 @@ class Route extends BaseModel
         return $route;
     }
 
-    public function points()
+    public function points(): ?array
     {
         return $this->belongsToMany(Point::class, 'route_points', 'route_id', 'point_id', 'id', 'id', true);
     }


### PR DESCRIPTION
This pull request focuses on improving type safety and return types in the `BaseModel` and `Route` classes. The changes ensure that methods have explicit type hints for their parameters and return types, which enhances code readability and reduces potential runtime errors.

Key changes include:

### Type Safety Enhancements:

* [`src/app/Models/BaseModel.php`](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L97-R97): Updated method signatures to include type hints for parameters and return types. This affects methods such as `count`, `exists`, `find`, `findAll`, `findBy`, `findSoftDeleted`, `hasOne`, `paginate`, and abstract methods `getTableName` and `mapDataToModel`. [[1]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L97-R97) [[2]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L129-R129) [[3]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L148-R148) [[4]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L163-R163) [[5]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L186-R186) [[6]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L218-R218) [[7]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L231-R231) [[8]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L274-R274) [[9]](diffhunk://#diff-878584d507d415f0091c62359e679487aa677d2b84830e88421dfa26f7888124L334-R343)

* [`src/app/Models/Route.php`](diffhunk://#diff-32bfed365173dc4975f82d5b85099dae7a28dd03d3dc14544e127bd67633344bL27-R27): Added return type hints to the `points` method to specify that it returns an array or null.