### PR TITLE
fix(tree-types): update links from create, edit and delete

### DIFF
--- a/src/app/Views/Admin/TreeType/Create.php
+++ b/src/app/Views/Admin/TreeType/Create.php
@@ -1,5 +1,5 @@
 <div class="mb-4 flex justify-end">
-    <a href="/tree-types"
+    <a href="/tree-types/"
         class="bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-lg shadow focus:outline-none focus:ring focus:ring-green-500 flex items-center space-x-2">
         <!-- Heroicon for return/back (chevron-left) -->
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -11,7 +11,7 @@
 
 <div class="bg-white p-8 border border-gray-300 rounded-lg shadow-md">
     <h2 class="text-2xl font-semibold text-gray-800 mb-6">Create Tree Type</h2>
-    <form action="/tree-type/store" method="POST" class="space-y-6">
+    <form action="/admin/tree-type/store" method="POST" class="space-y-6">
 
         <!-- Family -->
         <div>

--- a/src/app/Views/Admin/TreeType/Edit.php
+++ b/src/app/Views/Admin/TreeType/Edit.php
@@ -11,7 +11,7 @@
 
 <div class="bg-white p-8 border border-gray-300 rounded-lg shadow-md">
     <h2 class="text-2xl font-semibold text-gray-800 mb-6">Edit Tree Type</h2>
-    <form action="/tree-type/<?php echo htmlspecialchars($tree_type->getId()); ?>/update" method="POST"
+    <form action="/admin/tree-type/<?php echo htmlspecialchars($tree_type->getId()); ?>/update" method="POST"
         class="space-y-6">
 
         <!-- Family -->

--- a/src/app/Views/Admin/TreeTypes.php
+++ b/src/app/Views/Admin/TreeTypes.php
@@ -12,7 +12,7 @@ use App\Core\Session;
 <?php } ?>
 
 <div class="mb-4 flex justify-end">
-    <a href="/tree-type/create"
+    <a href="/admin/tree-type/create"
         class="bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-lg shadow focus:outline-none focus:ring focus:ring-green-500">
         Create Tree Type
     </a>
@@ -46,7 +46,7 @@ use App\Core\Session;
                     </td>
                     <td class="px-4 py-3 border-b text-center flex justify-center space-x-4">
                         <!-- Edit Button (Pencil Icon) -->
-                        <a href="/tree-type/<?php echo htmlspecialchars($tree_type->getId()); ?>/edit"
+                        <a href="/admin/tree-type/<?php echo htmlspecialchars($tree_type->getId()); ?>/edit"
                             class="text-blue-500 hover:text-blue-700" title="Edit">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                                 stroke="currentColor" class="w-5 h-5">
@@ -55,7 +55,7 @@ use App\Core\Session;
                             </svg>
                         </a>
                         <!-- Delete Button (Trash Icon) -->
-                        <a href="/tree-type/<?php echo htmlspecialchars($tree_type->getId()); ?>/delete"
+                        <a href="/admin/tree-type/<?php echo htmlspecialchars($tree_type->getId()); ?>/delete"
                             onclick="return confirm('Are you sure you want to delete this tree type?');"
                             class="text-red-500 hover:text-red-700" title="Delete">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"


### PR DESCRIPTION
This pull request includes changes to the URLs in several files to ensure they follow a consistent structure by adding the `/admin` prefix. The most important changes include updates to the `Create`, `Edit`, and `TreeTypes` views.

URL updates for consistency:

* [`src/app/Views/Admin/TreeType/Create.php`](diffhunk://#diff-b5fc91cbc00701c4904cf5380e8153db0cb8385cb26d21626594cd6c5947df06L2-R2): Updated the form action URL to `/admin/tree-type/store` and the back link URL to `/tree-types/`. [[1]](diffhunk://#diff-b5fc91cbc00701c4904cf5380e8153db0cb8385cb26d21626594cd6c5947df06L2-R2) [[2]](diffhunk://#diff-b5fc91cbc00701c4904cf5380e8153db0cb8385cb26d21626594cd6c5947df06L14-R14)
* [`src/app/Views/Admin/TreeType/Edit.php`](diffhunk://#diff-9d33f489f9fadfeea6be89d03ffc68c7262d2cd5622b87c8f986b4e05cd688a3L14-R14): Updated the form action URL to `/admin/tree-type/<?php echo htmlspecialchars($tree_type->getId()); ?>/update`.
* [`src/app/Views/Admin/TreeTypes.php`](diffhunk://#diff-063db1f485a6804bc273aa41160539af023ba642015a5e863be861f5935ded2bL15-R15): Updated the URLs for creating, editing, and deleting tree types to include the `/admin` prefix. [[1]](diffhunk://#diff-063db1f485a6804bc273aa41160539af023ba642015a5e863be861f5935ded2bL15-R15) [[2]](diffhunk://#diff-063db1f485a6804bc273aa41160539af023ba642015a5e863be861f5935ded2bL49-R49) [[3]](diffhunk://#diff-063db1f485a6804bc273aa41160539af023ba642015a5e863be861f5935ded2bL58-R58)