### PR TITLE
fix(api): update image version handling and remove SENTRY_RELEASE property

### DIFF
--- a/api/src/config.py
+++ b/api/src/config.py
@@ -32,8 +32,8 @@ class Settings(BaseSettings):
     def check_image_version(cls, v):
         if v == "":
             return None
-        if v.startswith("v"):
-            return v[1:]
+        if v and not v.startswith("v"):
+            return f"v{v}"
         return v
 
     @model_validator(mode="before")
@@ -74,12 +74,6 @@ class Settings(BaseSettings):
             port=self.MARIADB_PORT,
             path=self.MARIADB_DB,
         )
-
-    @computed_field
-    @property
-    def SENTRY_RELEASE(self) -> str | None:
-        if self.APP_ENV == "production":
-            return f"{self.APP_PACKAGE}@{self.IMAGE_VERSION}"
 
 
 settings = Settings()

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -12,7 +12,7 @@ from .services.scheduler_service import scheduler
 sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
     environment=settings.APP_ENV,
-    release=settings.SENTRY_RELEASE,
+    release=settings.IMAGE_VERSION,
     enable_tracing=True,
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for tracing.
@@ -48,4 +48,4 @@ def hello():
 
 @app.get("/health")
 def health_check():
-    return {"status": "healthy", "version": settings.SENTRY_RELEASE or "dev"}
+    return {"status": "healthy", "version": settings.IMAGE_VERSION or "dev"}

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -22,7 +22,6 @@ def test_settings_defaults():
         str(settings.SQLALCHEMY_DATABASE_URI)
         == "mysql+pymysql://user:password@localhost:3306/test_db"
     )
-    assert settings.SENTRY_RELEASE is None
 
 
 def test_settings_with_custom_settings():
@@ -30,7 +29,7 @@ def test_settings_with_custom_settings():
         APP_NAME="api",
         APP_PACKAGE="api2",
         APP_ENV="production",
-        IMAGE_VERSION="1.0.0",
+        IMAGE_VERSION="v1.0.0",
         MARIADB_SERVER="127.0.0.1",
         MARIADB_PORT=3307,
         MARIADB_USER="user2",
@@ -41,7 +40,7 @@ def test_settings_with_custom_settings():
     assert custom.APP_NAME == "api"
     assert custom.APP_PACKAGE == "api2"
     assert custom.APP_ENV == "production"
-    assert custom.IMAGE_VERSION == "1.0.0"
+    assert custom.IMAGE_VERSION == "v1.0.0"
     assert custom.MARIADB_SERVER == "127.0.0.1"
     assert custom.MARIADB_PORT == 3307
     assert custom.MARIADB_USER == "user2"
@@ -52,16 +51,13 @@ def test_settings_with_custom_settings():
         str(custom.SQLALCHEMY_DATABASE_URI)
         == "mysql+pymysql://user2:password2@127.0.0.1:3307/test_db2"
     )
-    assert custom.SENTRY_RELEASE == "api2@1.0.0"
 
 
-def test_v_prefixed_image_version():
+def test_image_version_without_v_prefix():
     custom = Settings(
-        APP_ENV="production",
-        IMAGE_VERSION="v1.0.0",
+        IMAGE_VERSION="1.0.0",
     )
-    assert custom.IMAGE_VERSION == "1.0.0"
-    assert custom.SENTRY_RELEASE == "api@1.0.0"
+    assert custom.IMAGE_VERSION == "v1.0.0"
 
 
 def test_settings_missing_password():


### PR DESCRIPTION
This pull request includes changes to the `api/src` and `api/tests` directories to modify how the `IMAGE_VERSION` is handled and to remove the `SENTRY_RELEASE` property. The changes ensure that the `IMAGE_VERSION` always starts with a 'v' prefix and simplify the configuration settings.

Configuration changes:

* [`api/src/config.py`](diffhunk://#diff-7df7ccee5a6672bf04f67eebb5964559fbbf239d77f594c8756ba3110e56fae0L35-R36): Modified the `check_image_version` method to ensure the `IMAGE_VERSION` starts with a 'v' prefix. Removed the `SENTRY_RELEASE` property from the `Settings` class. [[1]](diffhunk://#diff-7df7ccee5a6672bf04f67eebb5964559fbbf239d77f594c8756ba3110e56fae0L35-R36) [[2]](diffhunk://#diff-7df7ccee5a6672bf04f67eebb5964559fbbf239d77f594c8756ba3110e56fae0L78-L83)

Usage updates:

* [`api/src/main.py`](diffhunk://#diff-c03edaf8ac6a8151e382b7dfd02a323226733c4c4c000af2eb658ca692ccd793L15-R15): Updated references to `SENTRY_RELEASE` to use `IMAGE_VERSION` instead in the Sentry initialization and health check endpoint. [[1]](diffhunk://#diff-c03edaf8ac6a8151e382b7dfd02a323226733c4c4c000af2eb658ca692ccd793L15-R15) [[2]](diffhunk://#diff-c03edaf8ac6a8151e382b7dfd02a323226733c4c4c000af2eb658ca692ccd793L51-R51)

Test adjustments:

* [`api/tests/test_config.py`](diffhunk://#diff-9c77b4f9a6f75032e644de8b5d501ca971379aaf4f4214f4f6e4b881959b8f00L25-R32): Removed assertions related to `SENTRY_RELEASE` and updated tests to reflect the new handling of `IMAGE_VERSION` with a 'v' prefix. [[1]](diffhunk://#diff-9c77b4f9a6f75032e644de8b5d501ca971379aaf4f4214f4f6e4b881959b8f00L25-R32) [[2]](diffhunk://#diff-9c77b4f9a6f75032e644de8b5d501ca971379aaf4f4214f4f6e4b881959b8f00L44-R43) [[3]](diffhunk://#diff-9c77b4f9a6f75032e644de8b5d501ca971379aaf4f4214f4f6e4b881959b8f00L55-R60)