### PR TITLE
fix(workflows): update output variable for version in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
       pull-requests: read
     outputs:
-      version: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
 
     steps:
       # https://github.com/actions/checkout/tree/11bd71901bbe5b1630ceea73d27597364c9af683

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -32,8 +32,8 @@ class Settings(BaseSettings):
     def check_image_version(cls, v):
         if v == "":
             return None
-        if v and not v.startswith("v"):
-            return f"v{v}"
+        if v.startswith("v"):
+            return v[1:]
         return v
 
     @model_validator(mode="before")

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -29,7 +29,7 @@ def test_settings_with_custom_settings():
         APP_NAME="api",
         APP_PACKAGE="api2",
         APP_ENV="production",
-        IMAGE_VERSION="v1.0.0",
+        IMAGE_VERSION="1.0.0",
         MARIADB_SERVER="127.0.0.1",
         MARIADB_PORT=3307,
         MARIADB_USER="user2",
@@ -40,7 +40,7 @@ def test_settings_with_custom_settings():
     assert custom.APP_NAME == "api"
     assert custom.APP_PACKAGE == "api2"
     assert custom.APP_ENV == "production"
-    assert custom.IMAGE_VERSION == "v1.0.0"
+    assert custom.IMAGE_VERSION == "1.0.0"
     assert custom.MARIADB_SERVER == "127.0.0.1"
     assert custom.MARIADB_PORT == 3307
     assert custom.MARIADB_USER == "user2"
@@ -53,11 +53,11 @@ def test_settings_with_custom_settings():
     )
 
 
-def test_image_version_without_v_prefix():
+def test_image_version_wit_v_prefix():
     custom = Settings(
-        IMAGE_VERSION="1.0.0",
+        IMAGE_VERSION="v1.0.0",
     )
-    assert custom.IMAGE_VERSION == "v1.0.0"
+    assert custom.IMAGE_VERSION == "1.0.0"
 
 
 def test_settings_missing_password():


### PR DESCRIPTION
This pull request includes changes to the continuous deployment workflow and the configuration settings for image versions. The most important changes include updating the workflow output version format and modifying the image version handling in the configuration and tests.

### Workflow Updates:
* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L25-R25): Updated the workflow output to use `steps.release.outputs.version` instead of `steps.release.outputs.tag_name`.

### Configuration and Test Updates:
* [`api/src/config.py`](diffhunk://#diff-7df7ccee5a6672bf04f67eebb5964559fbbf239d77f594c8756ba3110e56fae0L35-R36): Modified the `check_image_version` method to strip the 'v' prefix from image versions if present.
* [`api/tests/test_config.py`](diffhunk://#diff-9c77b4f9a6f75032e644de8b5d501ca971379aaf4f4214f4f6e4b881959b8f00L32-R32): Updated tests to reflect the new image version format without the 'v' prefix. [[1]](diffhunk://#diff-9c77b4f9a6f75032e644de8b5d501ca971379aaf4f4214f4f6e4b881959b8f00L32-R32) [[2]](diffhunk://#diff-9c77b4f9a6f75032e644de8b5d501ca971379aaf4f4214f4f6e4b881959b8f00L43-R43) [[3]](diffhunk://#diff-9c77b4f9a6f75032e644de8b5d501ca971379aaf4f4214f4f6e4b881959b8f00L56-R60)