### PR TITLE
fix(workflows): update version output step in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
       pull-requests: read
     outputs:
-      version: ${{ steps.release.outputs.version }}
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       # https://github.com/actions/checkout/tree/11bd71901bbe5b1630ceea73d27597364c9af683
@@ -34,16 +34,13 @@ jobs:
         id: release
         with:
           bump_version_scheme: patch
-          tag_prefix: v
           use_github_release_notes: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: 🔎 Check Output Parameters
-        run: |
-          echo "Got tag name ${{ steps.release.outputs.tag_name }}"
-          echo "Got release version ${{ steps.release.outputs.version }}"
-          echo "Upload release artifacts to ${{ steps.release.outputs.upload_url }}"
+      - name: 📦 Set the version
+        id: version
+        run: echo "version=$(echo "${{ steps.release.outputs.tag_name }}" | cut -c 2-)" >> "$GITHUB_OUTPUT"
 
   build:
     name: 🏗️ Build


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/cd.yml` file to improve the versioning process in the CD pipeline. The most important changes are listed below:

Improvements to versioning process:

* Changed the output parameter `version` to use the `version` step instead of the `release` step.
* Removed the `tag_prefix` parameter from the `release` step configuration.
* Replaced the `Check Output Parameters` step with a new step named `Set the version` to extract and set the version from the tag name.