### PR TITLE
fix: typo in text-red class for error messages in forms

### DIFF
--- a/app/src/app/Views/Admin/Contract/Edit.php
+++ b/app/src/app/Views/Admin/Contract/Edit.php
@@ -13,7 +13,7 @@
     <form id="contractForm" action="/admin/contract/<?= htmlspecialchars($contract->getId()); ?>/update" method="POST"
         class="space-y-6">
         <div id="errorMessages"
-            class="hidden bg-red-100 border border-red-400 text-red700 px-4 py-3 rounded relative mb-6"></div>
+            class="hidden bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-6"></div>
 
         <div>
             <label for="name" class="block text-sm font-medium text-gray-700 mb-1">Nombre</label>

--- a/app/src/app/Views/Admin/TreeType/Create.php
+++ b/app/src/app/Views/Admin/TreeType/Create.php
@@ -12,7 +12,7 @@
 
     <form id="treeTypeForm" action="/admin/tree-type/store" method="POST" class="space-y-6">
         <div id="errorMessages"
-            class="hidden bg-red-100 border border-red-400 text-red700 px-4 py-3 rounded relative mb-6"></div>
+            class="hidden bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-6"></div>
         <div>
             <label for="family" class="block text-sm font-medium text-gray-700 mb-1">Familia</label>
             <input type="text" id="family" name="family"

--- a/app/src/app/Views/Admin/TreeType/Edit.php
+++ b/app/src/app/Views/Admin/TreeType/Edit.php
@@ -13,7 +13,7 @@
     <form id="treeTypeForm" action="/admin/tree-type/<?= htmlspecialchars($tree_type->getId()); ?>/update" method="POST"
         class="space-y-6">
         <div id="errorMessages"
-            class="hidden bg-red-100 border border-red-400 text-red700 px-4 py-3 rounded relative mb-6"></div>
+            class="hidden bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-6"></div>
         <div>
             <label for="family" class="block text-sm font-medium text-gray-700 mb-1">Familia</label>
             <input type="text" id="family" name="family" value="<?= htmlspecialchars($tree_type->family); ?>"


### PR DESCRIPTION
Correct the typo in the `text-red` class to `text-red-700` for consistent error message styling across multiple forms.