### PR TITLE
fix: :ambulance: remove success and error messages from session after view render

### DIFF
--- a/app/src/app/Core/View.php
+++ b/app/src/app/Core/View.php
@@ -27,5 +27,13 @@ class View
         } else {
             throw new Exception("Layout file not found: {$layout}");
         }
+
+        if (Session::has('success')) {
+            Session::remove('success');
+        }
+
+        if (Session::has('error')) {
+            Session::remove('error');
+        }
     }
 }


### PR DESCRIPTION
This pull request includes a small change to the `app/src/app/Core/View.php` file. The change ensures that any 'success' or 'error' messages in the session are removed after rendering the view.

* [`app/src/app/Core/View.php`](diffhunk://#diff-8e660a412baa16e6f91dcba39b61a3af90782cb2f1a31ae38a72f115bf539af4R30-R37): Added checks to remove 'success' and 'error' messages from the session if they exist.