### PR TITLE
fix: error 500 when not valid contracts found

### DIFF
--- a/app/src/app/Controllers/Auth/AuthController.php
+++ b/app/src/app/Controllers/Auth/AuthController.php
@@ -55,6 +55,9 @@ class AuthController
                     break;
                 }
             }
+            if (!isset($contract_id)) {
+                $contract_id = -1;
+            }
         } else {
             $contract_id = null;
         }

--- a/database/start-scripts/1-seed.sql
+++ b/database/start-scripts/1-seed.sql
@@ -7,9 +7,9 @@ INSERT INTO users (company, name, surname, dni, password, email, role) VALUES
 
 --* Contracts
 INSERT INTO contracts (name, start_date, end_date, invoice_proposed, invoice_agreed, invoice_paid) VALUES
-('Ayuntamiento de Valencia', '2021-01-01', '2021-12-31', 1000.00, 900.00, 900.00),
-('Administración General del Estado', '2021-01-01', '2021-12-31', 2000.00, 1800.00, 1800.00),
-('Ayuntamiento de Carlet', '2021-01-01', '2021-12-31', 3000.00, 2700.00, 2700.00);
+('Ayuntamiento de Valencia', '2021-01-01', '2026-12-31', 1000.00, 900.00, 900.00),
+('Administración General del Estado', '2026-01-01', '2021-12-31', 2000.00, 1800.00, 1800.00),
+('Ayuntamiento de Carlet', '2021-01-01', '2026-12-31', 3000.00, 2700.00, 2700.00);
 
 --* Machines
 INSERT INTO machines (name, max_basket_size) VALUES


### PR DESCRIPTION
### Fix: Error 500 when no valid contracts found

This PR fixes an issue where logging in resulted in a 500 error if no valid contracts were found.  
The problem was caused by seeder contract dates being identical and older than the current date, leaving `current_contract` as `null` in the session.
