### PR TITLE
fix: prevent modification and deletion of the only admin user

### DIFF
--- a/app/src/app/Controllers/Admin/UserController.php
+++ b/app/src/app/Controllers/Admin/UserController.php
@@ -95,11 +95,16 @@ class UserController
     public function destroy($id, $queryParams)
     {
         $user = User::find($id);
-        if ($user) {
+
+        // verify the role
+        $admin_count = User::count(['role' => 2]);
+        if ($admin_count = 1) {
+            Session::set('error', 'No se puede eliminar el único administrador');
+        } else if ($user->role != 2) {
             $user->delete();
             Session::set('success', 'Usuario eliminado correctamente');
         } else
-            Session::set('error', 'Usuario no encontrado');
+            Session::set('error', 'No se pueden eliminar administradores');
 
         header('Location: /admin/users');
         exit;

--- a/app/src/app/Controllers/Admin/UserController.php
+++ b/app/src/app/Controllers/Admin/UserController.php
@@ -98,7 +98,7 @@ class UserController
 
         // verify the role
         $admin_count = User::count(['role' => 2]);
-        if ($admin_count = 1) {
+        if ($admin_count == 1) {
             Session::set('error', 'No se puede eliminar el único administrador');
         } else if ($user->role != 2) {
             $user->delete();

--- a/app/src/app/Controllers/Admin/UserController.php
+++ b/app/src/app/Controllers/Admin/UserController.php
@@ -79,7 +79,7 @@ class UserController
         $admin_count = User::count(['role' => 2]);
 
         if ($admin_count == 1 && $user->role == 2 && $user->role != $postData['role']) {
-            Session::set('error', 'No se puede cambiar el rol al único un administrador');
+            Session::set('error', 'No se puede cambiar el rol al único administrador');
             header('Location: /admin/users');
             exit;
         }
@@ -109,11 +109,11 @@ class UserController
         $admin_count = User::count(['role' => 2]);
         if ($admin_count == 1) {
             Session::set('error', 'No se puede eliminar el único administrador');
-        } else if ($user->role != 2) {
+        } else if ($user) {
             $user->delete();
             Session::set('success', 'Usuario eliminado correctamente');
         } else
-            Session::set('error', 'No se pueden eliminar administradores');
+            Session::set('error', 'Usuario no encontrado');
 
         header('Location: /admin/users');
         exit;

--- a/app/src/app/Controllers/Admin/UserController.php
+++ b/app/src/app/Controllers/Admin/UserController.php
@@ -75,6 +75,15 @@ class UserController
     public function update($id, $postData)
     {
         $user = User::find($id);
+
+        $admin_count = User::count(['role' => 2]);
+
+        if ($admin_count == 1 && $user->role == 2 && $user->role != $postData['role']) {
+            Session::set('error', 'No se puede cambiar el rol a un administrador');
+            header('Location: /admin/users');
+            exit;
+        }
+
         if ($user) {
             $user->company = $postData['company'];
             $user->name = $postData['name'];

--- a/app/src/app/Controllers/Admin/UserController.php
+++ b/app/src/app/Controllers/Admin/UserController.php
@@ -79,7 +79,7 @@ class UserController
         $admin_count = User::count(['role' => 2]);
 
         if ($admin_count == 1 && $user->role == 2 && $user->role != $postData['role']) {
-            Session::set('error', 'No se puede cambiar el rol a un administrador');
+            Session::set('error', 'No se puede cambiar el rol al único un administrador');
             header('Location: /admin/users');
             exit;
         }


### PR DESCRIPTION
This pull request includes important changes to the `UserController` in the `app/src/app/Controllers/Admin` directory. These changes add checks to ensure that the last administrator cannot have their role changed or be deleted.

Key changes include:

* **Role Change Verification**:
  * In the `update` method, added a check to prevent changing the role of the last remaining administrator. If there is only one administrator and the role is being changed, an error message is set and the process is halted.

* **Deletion Verification**:
  * In the `destroy` method, added a check to prevent deleting the last remaining administrator. If there is only one administrator, an error message is set and the user is not deleted.