### PR TITLE
Add empty state messages for tree and element types in admin view

### DIFF
--- a/app/src/app/Views/Admin/ElementTypes.php
+++ b/app/src/app/Views/Admin/ElementTypes.php
@@ -18,42 +18,48 @@
             </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
-            <?php foreach ($element_types as $element_type) { ?>
-                <tr class="hover:bg-gray-50 transition-colors duration-300">
-                    <th scope="row" class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap">
-                        <?= htmlspecialchars($element_type->name); ?>
-                    </th>
-                    <td class="px-4 py-3">
-                        <?= htmlspecialchars($element_type->description); ?>
-                    </td>
-                    <td class="px-4 py-3">
-                        <?= $element_type->requires_tree_type ? "Sí" : "No"; ?>
-                    </td>
-                    <td class="px-4 py-3">
-                        <i class="<?= htmlspecialchars($element_type->icon); ?>"></i>
-                    </td>
-                    <td class="px-4 py-3">
-                        <span style="color: <?= htmlspecialchars($element_type->color); ?>;">■</span>
-                    </td>
-                    <td class="px-4 py-3">
-                        <?= count($element_type->elements()); ?>
-                    </td>
-                    <td class="px-4 py-3 text-center">
-                        <div class="flex justify-center space-x-3">
-                            <a href="/admin/element-type/<?= htmlspecialchars($element_type->getId()); ?>/edit"
-                                class="p-2 text-gray-700 border border-transparent hover:text-gray-500 transition-all duration-200"
-                                title="Editar" aria-label="Editar tipo de elemento <?= htmlspecialchars($element_type->name); ?>">
-                                <i class="fas fa-pencil"></i>
-                            </a>
-                            <a href="/admin/element-type/<?= htmlspecialchars($element_type->getId()); ?>/delete"
-                                onclick="return confirm('¿Desea eliminar el tipo de elemento <?= htmlspecialchars($element_type->name); ?>?');"
-                                class="p-2 text-gray-700 border border-transparent hover:text-red-500 transition-all duration-200"
-                                title="Eliminar" aria-label="Eliminar tipo de elemento <?= htmlspecialchars($element_type->name); ?>">
-                                <i class="fas fa-trash-alt"></i>
-                            </a>
-                        </div>
-                    </td>
+            <?php if (empty($element_types)) { ?>
+                <tr>
+                    <td colspan="5" class="px-4 py-3 text-center text-gray-500">No hay elementos disponibles.</td>
                 </tr>
+            <?php } else { ?>
+                <?php foreach ($element_types as $element_type) { ?>
+                    <tr class="hover:bg-gray-50 transition-colors duration-300">
+                        <th scope="row" class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap">
+                            <?= htmlspecialchars($element_type->name); ?>
+                        </th>
+                        <td class="px-4 py-3">
+                            <?= htmlspecialchars($element_type->description); ?>
+                        </td>
+                        <td class="px-4 py-3">
+                            <?= $element_type->requires_tree_type ? "Sí" : "No"; ?>
+                        </td>
+                        <td class="px-4 py-3">
+                            <i class="<?= htmlspecialchars($element_type->icon); ?>"></i>
+                        </td>
+                        <td class="px-4 py-3">
+                            <span style="color: <?= htmlspecialchars($element_type->color); ?>;">■</span>
+                        </td>
+                        <td class="px-4 py-3">
+                            <?= count($element_type->elements()); ?>
+                        </td>
+                        <td class="px-4 py-3 text-center">
+                            <div class="flex justify-center space-x-3">
+                                <a href="/admin/element-type/<?= htmlspecialchars($element_type->getId()); ?>/edit"
+                                    class="p-2 text-gray-700 border border-transparent hover:text-gray-500 transition-all duration-200"
+                                    title="Editar" aria-label="Editar tipo de elemento <?= htmlspecialchars($element_type->name); ?>">
+                                    <i class="fas fa-pencil"></i>
+                                </a>
+                                <a href="/admin/element-type/<?= htmlspecialchars($element_type->getId()); ?>/delete"
+                                    onclick="return confirm('¿Desea eliminar el tipo de elemento <?= htmlspecialchars($element_type->name); ?>?');"
+                                    class="p-2 text-gray-700 border border-transparent hover:text-red-500 transition-all duration-200"
+                                    title="Eliminar" aria-label="Eliminar tipo de elemento <?= htmlspecialchars($element_type->name); ?>">
+                                    <i class="fas fa-trash-alt"></i>
+                                </a>
+                            </div>
+                        </td>
+                    </tr>
+                <?php } ?>
             <?php } ?>
         </tbody>
     </table>

--- a/app/src/app/Views/Admin/ElementTypes.php
+++ b/app/src/app/Views/Admin/ElementTypes.php
@@ -20,7 +20,7 @@
         <tbody class="divide-y divide-gray-200 bg-white">
             <?php if (empty($element_types)) { ?>
                 <tr>
-                    <td colspan="5" class="px-4 py-3 text-center text-gray-500">No hay elementos disponibles.</td>
+                    <td colspan="7" class="px-4 py-3 text-center text-gray-500">No hay tipos elementos disponibles.</td>
                 </tr>
             <?php } else { ?>
                 <?php foreach ($element_types as $element_type) { ?>

--- a/app/src/app/Views/Admin/TreeTypes.php
+++ b/app/src/app/Views/Admin/TreeTypes.php
@@ -16,9 +16,9 @@
             </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
-            <?php if (empty($task_types)) { ?>
+            <?php if (empty($tree_types)) { ?>
                 <tr>
-                    <td colspan="5" class="px-4 py-3 text-center text-gray-500">No hay tipos de tarea disponibles.</td>
+                    <td colspan="5" class="px-4 py-3 text-center text-gray-500">No hay especies disponibles.</td>
                 </tr>
             <?php } else { ?>
                 <?php foreach ($tree_types as $tree_type) { ?>

--- a/app/src/app/Views/Admin/TreeTypes.php
+++ b/app/src/app/Views/Admin/TreeTypes.php
@@ -16,36 +16,42 @@
             </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
-            <?php foreach ($tree_types as $tree_type) { ?>
-                <tr class="hover:bg-gray-50 transition-colors duration-300">
-                    <th scope="row" class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap">
-                        <?= htmlspecialchars($tree_type->species); ?>
-                    </th>
-                    <td class="px-4 py-3">
-                        <?= htmlspecialchars($tree_type->genus); ?>
-                    </td>
-                    <td class="px-4 py-3">
-                        <?= htmlspecialchars($tree_type->family); ?>
-                    </td>
-                    <td class="px-4 py-3">
-                        <?= count($tree_type->elements()); ?>
-                    </td>
-                    <td class="px-4 py-3 text-center">
-                        <div class="flex justify-center space-x-3">
-                            <a href="/admin/tree-type/<?= htmlspecialchars($tree_type->getId()); ?>/edit"
-                                class="p-2 text-gray-700 border border-transparent hover:text-gray-500 transition-all duration-200"
-                                title="Editar" aria-label="Editar especie <?= htmlspecialchars($tree_type->species); ?>">
-                                <i class="fas fa-pencil"></i>
-                            </a>
-                            <a href="/admin/tree-type/<?= htmlspecialchars($tree_type->getId()); ?>/delete"
-                                onclick="return confirm('¿Desea eliminar la especie <?= htmlspecialchars($tree_type->species); ?>?');"
-                                class="p-2 text-gray-700 border border-transparent hover:text-red-500 transition-all duration-200"
-                                title="Eliminar" aria-label="Eliminar especie <?= htmlspecialchars($tree_type->species); ?>">
-                                <i class="fas fa-trash-alt"></i>
-                            </a>
-                        </div>
-                    </td>
+            <?php if (empty($task_types)) { ?>
+                <tr>
+                    <td colspan="5" class="px-4 py-3 text-center text-gray-500">No hay tipos de tarea disponibles.</td>
                 </tr>
+            <?php } else { ?>
+                <?php foreach ($tree_types as $tree_type) { ?>
+                    <tr class="hover:bg-gray-50 transition-colors duration-300">
+                        <th scope="row" class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap">
+                            <?= htmlspecialchars($tree_type->species); ?>
+                        </th>
+                        <td class="px-4 py-3">
+                            <?= htmlspecialchars($tree_type->genus); ?>
+                        </td>
+                        <td class="px-4 py-3">
+                            <?= htmlspecialchars($tree_type->family); ?>
+                        </td>
+                        <td class="px-4 py-3">
+                            <?= count($tree_type->elements()); ?>
+                        </td>
+                        <td class="px-4 py-3 text-center">
+                            <div class="flex justify-center space-x-3">
+                                <a href="/admin/tree-type/<?= htmlspecialchars($tree_type->getId()); ?>/edit"
+                                    class="p-2 text-gray-700 border border-transparent hover:text-gray-500 transition-all duration-200"
+                                    title="Editar" aria-label="Editar especie <?= htmlspecialchars($tree_type->species); ?>">
+                                    <i class="fas fa-pencil"></i>
+                                </a>
+                                <a href="/admin/tree-type/<?= htmlspecialchars($tree_type->getId()); ?>/delete"
+                                    onclick="return confirm('¿Desea eliminar la especie <?= htmlspecialchars($tree_type->species); ?>?');"
+                                    class="p-2 text-gray-700 border border-transparent hover:text-red-500 transition-all duration-200"
+                                    title="Eliminar" aria-label="Eliminar especie <?= htmlspecialchars($tree_type->species); ?>">
+                                    <i class="fas fa-trash-alt"></i>
+                                </a>
+                            </div>
+                        </td>
+                    </tr>
+                <?php } ?>
             <?php } ?>
         </tbody>
     </table>

--- a/app/src/app/Views/Admin/WorkOrders.php
+++ b/app/src/app/Views/Admin/WorkOrders.php
@@ -15,99 +15,105 @@
             </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
-            <?php foreach ($work_orders as $index => $work_order) { ?>
-                <tr class="hover:bg-gray-50 transition-colors duration-300">
-                    <th scope="row" class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap">
-                        <button id="accordionButton<?php echo $index; ?>" onclick="toggleAccordion(<?php echo $index; ?>)"
-                            aria-expanded="false" class="text-gray-500 hover:text-gray-700 focus:outline-none mr-2">
-                            <!-- SVG Acordeon-->
-                            <svg id="accordionIcon<?php echo $index; ?>" xmlns="http://www.w3.org/2000/svg"
-                                class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path id="accordionPath<?php echo $index; ?>" stroke-linecap="round" stroke-linejoin="round"
-                                    stroke-width="2" d="M9 5l7 7-7 7" />
-                            </svg>
-                        </button>
-                        <?php echo "OT-" . htmlspecialchars($work_order->contract()->getId()); ?>
-                    </th>
-                    <td class="px-4 py-3">
-                        <?= date('d/m/Y', strtotime($work_order->date)); ?>
-                    </td>
-                    <td class="px-4 py-3">
-                        <?php
-                        $users = [];
-                        foreach ($work_order->users() as $user) {
-                            $users[] = $user->name . " " . $user->surname;
-                        }
-                        echo implode(', ', $users);
-                        ?>
-                    </td>
-                    <td class="px-4 py-3 text-center">
-                        <div class="flex justify-center space-x-3">
-                            <!-- Edit Button (Pencil Icon) -->
-                            <a href="/admin/work-order/<?php echo htmlspecialchars($work_order->getId()); ?>/edit"
-                                class="p-2 text-gray-700 border border-transparent hover:text-gray-500 transition-all duration-200"
-                                title="Editar" aria-label="Editar orden de trabajo OT-<?php echo htmlspecialchars($work_order->contract()->getId()); ?>">
-                                <i class="fas fa-pencil"></i>
-                            </a>
-                            <!-- Delete Button (Trash Icon) -->
-                            <a href="/admin/work-order/<?php echo htmlspecialchars($work_order->getId()); ?>/delete"
-                                onclick="return confirm('¿Está seguro de que desea eliminar esta orden de trabajo OT-<?php echo htmlspecialchars($work_order->contract()->getId()); ?>?');"
-                                class="p-2 text-gray-700 border border-transparent hover:text-red-500 transition-all duration-200"
-                                title="Eliminar" aria-label="Eliminar orden de trabajo OT-<?php echo htmlspecialchars($work_order->contract()->getId()); ?>">
-                                <i class="fas fa-trash-alt"></i>
-                            </a>
-                        </div>
-                    </td>
+            <?php if (empty($work_orders)) { ?>
+                <tr>
+                    <td colspan="5" class="px-4 py-3 text-center text-gray-500">No hay órdenes de trabajo disponibles.</td>
                 </tr>
-
-                <!-- Row Accordion -->
-                <tr id="accordionContent<?php echo $index; ?>" class="hidden">
-                    <td colspan="4" class="py-2 px-30">
-                        <?php foreach ($work_order->blocks() as $block) { ?>
-                            <div class="relative overflow-x-auto">
-                                <table class="w-full text-sm text-left text-gray-700">
-                                    <thead class="uppercase">
-                                        <tr>
-                                            <th scope="col" class="px-4 py-3 font-medium">Zonas</th>
-                                            <th scope="col" class="px-4 py-3 font-medium">Tipo de Tareas</th>
-                                            <th scope="col" class="px-4 py-3 font-medium">Notas</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody class="bg-white divide-y divide-gray-200">
-                                        <tr class="hover:bg-gray-100 transition-colors duration-300">
-                                            <td class="px-4 py-4 whitespace-nowrap w-1/3">
-                                                <ul>
-                                                    <?php foreach ($block->zones() as $blockZones) { ?>
-                                                        <li>• <?php echo htmlspecialchars($blockZones->name); ?></li>
-                                                    <?php } ?>
-                                                </ul>
-                                            </td>
-
-                                            <td class="px-4 py-4 w-1/3">
-                                                <ul>
-                                                    <?php foreach ($block->tasks() as $blockTask) { ?>
-                                                        <li>• <?php echo htmlspecialchars($blockTask->task()->name); ?>
-                                                            <?php if ($blockTask->treeType() != null) {
-                                                                echo ": " . htmlspecialchars($blockTask->treeType()->species);
-                                                            } ?>
-                                                        </li>
-                                                    <?php } ?>
-                                                </ul>
-                                            </td>
-
-                                            <td class="px-4 py-4 w-1/3">
-                                                <?php if ($block->notes !== null) {
-                                                    echo htmlspecialchars($block->notes);
-                                                } ?>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-
+            <?php } else { ?>
+                <?php foreach ($work_orders as $index => $work_order) { ?>
+                    <tr class="hover:bg-gray-50 transition-colors duration-300">
+                        <th scope="row" class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap">
+                            <button id="accordionButton<?php echo $index; ?>" onclick="toggleAccordion(<?php echo $index; ?>)"
+                                aria-expanded="false" class="text-gray-500 hover:text-gray-700 focus:outline-none mr-2">
+                                <!-- SVG Acordeon-->
+                                <svg id="accordionIcon<?php echo $index; ?>" xmlns="http://www.w3.org/2000/svg"
+                                    class="w-5 h-5 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path id="accordionPath<?php echo $index; ?>" stroke-linecap="round" stroke-linejoin="round"
+                                        stroke-width="2" d="M9 5l7 7-7 7" />
+                                </svg>
+                            </button>
+                            <?php echo "OT-" . htmlspecialchars($work_order->contract()->getId()); ?>
+                        </th>
+                        <td class="px-4 py-3">
+                            <?= date('d/m/Y', strtotime($work_order->date)); ?>
+                        </td>
+                        <td class="px-4 py-3">
+                            <?php
+                            $users = [];
+                            foreach ($work_order->users() as $user) {
+                                $users[] = $user->name . " " . $user->surname;
+                            }
+                            echo implode(', ', $users);
+                            ?>
+                        </td>
+                        <td class="px-4 py-3 text-center">
+                            <div class="flex justify-center space-x-3">
+                                <!-- Edit Button (Pencil Icon) -->
+                                <a href="/admin/work-order/<?php echo htmlspecialchars($work_order->getId()); ?>/edit"
+                                    class="p-2 text-gray-700 border border-transparent hover:text-gray-500 transition-all duration-200"
+                                    title="Editar" aria-label="Editar orden de trabajo OT-<?php echo htmlspecialchars($work_order->contract()->getId()); ?>">
+                                    <i class="fas fa-pencil"></i>
+                                </a>
+                                <!-- Delete Button (Trash Icon) -->
+                                <a href="/admin/work-order/<?php echo htmlspecialchars($work_order->getId()); ?>/delete"
+                                    onclick="return confirm('¿Está seguro de que desea eliminar esta orden de trabajo OT-<?php echo htmlspecialchars($work_order->contract()->getId()); ?>?');"
+                                    class="p-2 text-gray-700 border border-transparent hover:text-red-500 transition-all duration-200"
+                                    title="Eliminar" aria-label="Eliminar orden de trabajo OT-<?php echo htmlspecialchars($work_order->contract()->getId()); ?>">
+                                    <i class="fas fa-trash-alt"></i>
+                                </a>
                             </div>
-                        <?php } ?>
-                    </td>
-                </tr>
+                        </td>
+                    </tr>
+
+                    <!-- Row Accordion -->
+                    <tr id="accordionContent<?php echo $index; ?>" class="hidden">
+                        <td colspan="4" class="py-2 px-30">
+                            <?php foreach ($work_order->blocks() as $block) { ?>
+                                <div class="relative overflow-x-auto">
+                                    <table class="w-full text-sm text-left text-gray-700">
+                                        <thead class="uppercase">
+                                            <tr>
+                                                <th scope="col" class="px-4 py-3 font-medium">Zonas</th>
+                                                <th scope="col" class="px-4 py-3 font-medium">Tipo de Tareas</th>
+                                                <th scope="col" class="px-4 py-3 font-medium">Notas</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody class="bg-white divide-y divide-gray-200">
+                                            <tr class="hover:bg-gray-100 transition-colors duration-300">
+                                                <td class="px-4 py-4 whitespace-nowrap w-1/3">
+                                                    <ul>
+                                                        <?php foreach ($block->zones() as $blockZones) { ?>
+                                                            <li>• <?php echo htmlspecialchars($blockZones->name); ?></li>
+                                                        <?php } ?>
+                                                    </ul>
+                                                </td>
+
+                                                <td class="px-4 py-4 w-1/3">
+                                                    <ul>
+                                                        <?php foreach ($block->tasks() as $blockTask) { ?>
+                                                            <li>• <?php echo htmlspecialchars($blockTask->task()->name); ?>
+                                                                <?php if ($blockTask->treeType() != null) {
+                                                                    echo ": " . htmlspecialchars($blockTask->treeType()->species);
+                                                                } ?>
+                                                            </li>
+                                                        <?php } ?>
+                                                    </ul>
+                                                </td>
+
+                                                <td class="px-4 py-4 w-1/3">
+                                                    <?php if ($block->notes !== null) {
+                                                        echo htmlspecialchars($block->notes);
+                                                    } ?>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+
+                                </div>
+                            <?php } ?>
+                        </td>
+                    </tr>
+                <?php } ?>
             <?php } ?>
         </tbody>
     </table>


### PR DESCRIPTION
Introduce empty state messages for both tree types and element types in the admin view to enhance user experience when no data is available. Update existing messages for clarity.