### PR TITLE
fix(map): bugs and tweaks to improve usability

### DIFF
--- a/app/src/public/assets/js/map.js
+++ b/app/src/public/assets/js/map.js
@@ -1017,8 +1017,6 @@ document.addEventListener("DOMContentLoaded", () => {
     cancelZoneButton.innerHTML = "<i class='fas fa-times-circle'></i> Cancelar creación";
     document.getElementById("submenu").appendChild(cancelZoneButton);
 
-    window.setMode = setMode;
-
     fetchElementTypes();
     fetchTreeTypes();
 });

--- a/app/src/public/assets/js/map.js
+++ b/app/src/public/assets/js/map.js
@@ -59,15 +59,8 @@ document.addEventListener("DOMContentLoaded", () => {
     mapContainer.on("click", handleMapClick);
     mapContainer.on("load", loadZones);
 
-    zoneButton.addEventListener("click", () => {
-        console.log("Zone button clicked");
-        setMode(MODE.ZONE);
-    });
-
-    elementButton.addEventListener("click", () => {
-        console.log("Element button clicked");
-        setMode(MODE.ELEMENT);
-    });
+    zoneButton.addEventListener("click", () => setMode(MODE.ZONE));
+    elementButton.addEventListener("click", () => setMode(MODE.ELEMENT));
 
     // Functions
     function setActiveButton(activeButton) {
@@ -133,6 +126,8 @@ document.addEventListener("DOMContentLoaded", () => {
             };
 
             saveZone(newZone);
+            finishButton.classList.add("hidden");
+            cancelZoneButton.classList.add("hidden");
         }
     }
 
@@ -217,7 +212,6 @@ document.addEventListener("DOMContentLoaded", () => {
         if (currentMode === MODE.ZONE && isCreating) {
             const { lng, lat } = e.lngLat;
             zonePoints.push([lng, lat]);
-            console.log("Point added:", [lng, lat]);
 
             const markerElement = document.createElement("div");
             markerElement.style.cssText =
@@ -635,7 +629,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function createMarkerElement(icon, color) {
-        console.log("Creating marker element with icon:", icon);
         const markerElement = document.createElement("div");
         markerElement.style.cssText = `width: 40px; height: 40px; background-color: ${color}; border-radius: 50%; display: flex; align-items: center; justify-content: center; border: 1px solid white;`;
         markerElement.innerHTML = `<i class="${icon}" style="color: white; font-size: 20px;"></i>`;
@@ -645,28 +638,12 @@ document.addEventListener("DOMContentLoaded", () => {
     function drawZonePolygonOnMap(zone) {
         const polygonSourceId = `zone-polygon-${zone.id}`;
         const polygonLayerId = `zone-polygon-layer-${zone.id}`;
-
-        if (!mapContainer.isStyleLoaded()) {
-            mapContainer.on("styledata", () => {
-                if (
-                    !mapContainer.getSource(polygonSourceId) &&
-                    !mapContainer.getLayer(polygonLayerId)
-                ) {
-                    addPolygonSourceAndLayer(
-                        zone,
-                        polygonSourceId,
-                        polygonLayerId
-                    );
-                }
-            });
-        } else {
-            if (
+        if (
                 !mapContainer.getSource(polygonSourceId) &&
                 !mapContainer.getLayer(polygonLayerId)
             ) {
                 addPolygonSourceAndLayer(zone, polygonSourceId, polygonLayerId);
             }
-        }
     }
 
     function addPolygonSourceAndLayer(
@@ -800,6 +777,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
             const result = await response.json();
             if (result.status === "success") {
+                removeZonePolygons(zoneId);
+                zonesData.zones = zonesData.zones.filter((zone) => zone.id !== zoneId);
                 alert(`Zona ${zoneId} eliminada exitosamente.`);
                 reloadMap();
             } else {
@@ -809,6 +788,19 @@ document.addEventListener("DOMContentLoaded", () => {
             console.error(error);
             alert("Error al eliminar la zona.");
         }
+    }
+
+    function clearMap() {
+        if (zonesData.zones) {
+            zonesData.zones.forEach(zone => {
+                removeZonePolygons(zone.id);
+            });
+        }
+        Object.keys(markers).forEach(zoneId => {
+            removeMarkersForZone(zoneId);
+        });
+        zonesData = { zones: [] };
+        markers = {};
     }
 
     function showElementModal(el) {
@@ -876,15 +868,6 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     }
 
-    function clearMap() {
-        markers = [];
-        if (zonesData.zones) {
-            zonesData.zones.forEach(zone => {
-                removeZonePolygons(zone.id);
-            });
-        }
-    }
-
     function deleteElement(elementId) {
         fetch(`/api/map/elements`, {
                 method: "DELETE",
@@ -899,7 +882,6 @@ document.addEventListener("DOMContentLoaded", () => {
                 alert('Elemento eliminado correctamente.');
                 elementModal.classList.add("hidden");
                 removeElementMarker(elementId);
-                console.log('Element removed:', elementId);
             } else {
                 alert(`Error: ${result.message}`);
             }

--- a/app/src/public/assets/js/map.js
+++ b/app/src/public/assets/js/map.js
@@ -69,13 +69,6 @@ document.addEventListener("DOMContentLoaded", () => {
         setMode(MODE.ELEMENT);
     });
 
-    const mobileMenuToggle = document.getElementById("mobile-menu-toggle");
-    const mobileMenu = document.getElementById("mobile-menu");
-
-    mobileMenuToggle.addEventListener("click", function() {
-        mobileMenu.classList.toggle("hidden");
-    });
-
     // Functions
     function setActiveButton(activeButton) {
         const buttons = [zoneButton, elementButton];

--- a/app/src/public/assets/js/map.js
+++ b/app/src/public/assets/js/map.js
@@ -263,6 +263,9 @@ document.addEventListener("DOMContentLoaded", () => {
             if (isCreating) {
                 stopCreation();
             }
+            createButton.classList.add("text-gray-300");
+            createButton.classList.remove("text-gray-700");
+            createButton.setAttribute("disabled", "true");
         } else {
             currentMode = mode;
             setActiveButton(mode === MODE.ZONE ? zoneButton : elementButton);

--- a/database/start-scripts/1-seed.sql
+++ b/database/start-scripts/1-seed.sql
@@ -7,9 +7,7 @@ INSERT INTO users (company, name, surname, dni, password, email, role) VALUES
 
 --* Contracts
 INSERT INTO contracts (name, start_date, end_date, invoice_proposed, invoice_agreed, invoice_paid) VALUES
-('Ayuntamiento de Valencia', '2021-01-01', '2026-12-31', 1000.00, 900.00, 900.00),
-('Administración General del Estado', '2026-01-01', '2021-12-31', 2000.00, 1800.00, 1800.00),
-('Ayuntamiento de Carlet', '2021-01-01', '2026-12-31', 3000.00, 2700.00, 2700.00);
+('Demo', '2021-01-01', '2026-12-31', 1000.00, 900.00, 900.00);
 
 --* Element Types
 INSERT INTO element_types (name, description, requires_tree_type, icon, color) VALUES
@@ -31,9 +29,7 @@ INSERT INTO task_types (name, description) VALUES
 
 --* Zones
 INSERT INTO zones (name, contract_id, color, description) VALUES
-('Amposta A', 1, '#FF0000', 'Esta es una descripción de la zona 1.'),
-('Amposta B', 1, '#00FF00', 'Esta es una descripción de la zona 2.'),
-('Amposta C', 1, '#0000FF', 'Esta es una descripción de la zona 3.');
+('Amposta A', 1, '#FF0000', 'Esta es una descripción de la zona 1.');
 
 --* Points
 INSERT INTO points (latitude, longitude, zone_id, element_id) VALUES
@@ -76,8 +72,8 @@ INSERT INTO incidences (element_id, name, description) VALUES
 --* Work Orders
 INSERT INTO work_orders (contract_id, date) VALUES
 (1, "2021-01-01"),
-(2, "2021-02-01"),
-(3, "2021-03-01");
+(1, "2021-02-01"),
+(1, "2021-03-01");
 
 --* Work Orders Users
 INSERT INTO work_orders_users (work_order_id, user_id) VALUES
@@ -103,37 +99,26 @@ INSERT INTO sensor_history (sensor_id, temperature, humidity, inclination) VALUE
 
 --* Work Orders Blocks
 INSERT INTO work_orders_blocks (work_order_id, notes) VALUES
-(1, "Notas de la orden 1"),
-(2, "Notas de la orden 2"),
-(3, "Notas de la orden 3");
+(1,"Notas de la orden 1");
 
 --* Work Orders Blocks Zones
 INSERT INTO work_orders_blocks_zones (work_orders_block_id, zone_id) VALUES
-(1, 1),
-(1, 2),
-(2, 2),
-(3, 3);
+(1, 1);
 
 INSERT INTO work_orders_blocks_tasks (work_orders_block_id, task_id, tree_type_id, element_type_id) VALUES
-(1, 1, 1, 1),
-(1, 2, 2, 2),
-(2, 2, NULL,3),
-(3, 3, NULL, 2);
+(1, 1, 1, 1);
 
-INSERT INTO resource_type (id, name, description)
-VALUES
-    (1, 'Vehiculo', 'Resources that are in written book format'),
-    (2, 'Consumibles', 'Instructional or educational video content'),
-    (3, 'Maquinaria', 'Written articles or blogs for learning');
+INSERT INTO resource_type (id, name, description) VALUES
+(1, 'Vehiculo', 'Resources that are in written book format'),
+(2, 'Consumibles', 'Instructional or educational video content'),
+(3, 'Maquinaria', 'Written articles or blogs for learning');
 
-INSERT INTO resources (id, name, description, resource_type_id)
-VALUES
-    (1, 'Vechiculo A', NULL, 1),
-    (2, 'jocs infantils', NULL, 2),
-    (3, 'Corta Cesped', NULL, 3);
+INSERT INTO resources (id, name, description, resource_type_id) VALUES
+(1, 'Vechiculo A', NULL, 1),
+(2, 'jocs infantils', NULL, 2),
+(3, 'Corta Cesped', NULL, 3);
 
-INSERT INTO work_report_resources (id, work_report_id, resource_id)
-VALUES
-    (1, 1, 1),
-    (2, 1, 2),
-    (3, 1, 3);
+INSERT INTO work_report_resources (id, work_report_id, resource_id) VALUES
+(1, 1, 1),
+(2, 1, 2),
+(3, 1, 3);


### PR DESCRIPTION
This pull request includes various changes to the `app/src/public/assets/js/map.js` file to improve code readability and functionality, as well as updates to `database/start-scripts/1-seed.sql` to correct and streamline the initial data seeding process. The most important changes include removing unnecessary console logs, adding functionality to hide buttons, and updating the initial database seeding script to correct data entries.

Improvements to `map.js`:

* Removed unnecessary console logs to clean up the code (`app/src/public/assets/js/map.js`). [[1]](diffhunk://#diff-d2f8c0dc39fe7cb3f67aa82664539e919c4e2808c40623faa083908c5349aaeeL227) [[2]](diffhunk://#diff-d2f8c0dc39fe7cb3f67aa82664539e919c4e2808c40623faa083908c5349aaeeL642) [[3]](diffhunk://#diff-d2f8c0dc39fe7cb3f67aa82664539e919c4e2808c40623faa083908c5349aaeeL906)
* Added functionality to hide `finishButton` and `cancelZoneButton` after saving a zone (`app/src/public/assets/js/map.js`).
* Updated the `setMode` function to disable and style the `createButton` appropriately (`app/src/public/assets/js/map.js`).
* Removed redundant check for `mapContainer.isStyleLoaded()` in `drawZonePolygonOnMap` function (`app/src/public/assets/js/map.js`).
* Consolidated and enhanced the `clearMap` function to remove zone polygons and markers (`app/src/public/assets/js/map.js`). [[1]](diffhunk://#diff-d2f8c0dc39fe7cb3f67aa82664539e919c4e2808c40623faa083908c5349aaeeR793-R805) [[2]](diffhunk://#diff-d2f8c0dc39fe7cb3f67aa82664539e919c4e2808c40623faa083908c5349aaeeL883-L891)

Updates to `1-seed.sql`:

* Corrected and streamlined the data entries for contracts, zones, work orders, and related tables to ensure consistency and accuracy (`database/start-scripts/1-seed.sql`). [[1]](diffhunk://#diff-5fed4220a897d99dd339df4242f8979be9be1cbecac437862f21655b0db4cc4cL10-R10) [[2]](diffhunk://#diff-5fed4220a897d99dd339df4242f8979be9be1cbecac437862f21655b0db4cc4cL34-R32) [[3]](diffhunk://#diff-5fed4220a897d99dd339df4242f8979be9be1cbecac437862f21655b0db4cc4cL79-R76) [[4]](diffhunk://#diff-5fed4220a897d99dd339df4242f8979be9be1cbecac437862f21655b0db4cc4cL106-R121)