### PR TITLE
fix: update WorkOrder model to allow nullable WorkReport and handle observation safely

### DIFF
--- a/app/src/app/Models/WorkOrder.php
+++ b/app/src/app/Models/WorkOrder.php
@@ -26,7 +26,7 @@ class WorkOrder extends BaseModel
         return $work_order;
     }
 
-    public function report(): WorkReport
+    public function report(): ?WorkReport
     {
         return $this->hasOne(WorkReport::class, 'id');
     }
@@ -48,8 +48,8 @@ class WorkOrder extends BaseModel
 
     public function status()
     {
-        $tasks = array_merge(...array_map(fn ($block) => $block->tasks(), $this->blocks()));
-        $completed = count(array_filter($tasks, fn ($task) => $task->status == 1));
+        $tasks = array_merge(...array_map(fn($block) => $block->tasks(), $this->blocks()));
+        $completed = count(array_filter($tasks, fn($task) => $task->status == 1));
         $total = count($tasks);
 
         return $completed === $total ? 2 : ($completed > 0 ? 1 : 0);

--- a/app/src/app/Views/Worker/WorkOrders.php
+++ b/app/src/app/Views/Worker/WorkOrders.php
@@ -168,7 +168,7 @@
 
                 <div>
                     <p class="text-lg font-semibold text-gray-800">Observaciones:</p>
-                    <textarea name="observation" class="block w-full p-2.5 text-sm text-gray-800 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none mt-2" rows="4" placeholder="Escribe aquí tus observaciones..."><?= htmlspecialchars($work_report->observation) ?></textarea>
+                    <textarea name="observation" class="block w-full p-2.5 text-sm text-gray-800 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none mt-2" rows="4" placeholder="Escribe aquí tus observaciones..."><?= htmlspecialchars($work_report->observation ?? '') ?></textarea>
                 </div>
 
                 <button


### PR DESCRIPTION
This pull request includes updates to the `WorkOrder` model and the `WorkOrders` view to improve data handling and user experience. The most important changes are:

### Model Update:
* [`app/src/app/Models/WorkOrder.php`](diffhunk://#diff-b2a8b4d76a56d0ba0e5f297563bc8c27faa689d914445ae6697f019e20e4e2a4L29-R29): Modified the `report` method to return a nullable `WorkReport` object, ensuring compatibility when no report is associated with the work order.

### View Update:
* [`app/src/app/Views/Worker/WorkOrders.php`](diffhunk://#diff-e562e3af2c2629c5161f827c2563c380411b24f2427a2a1d4d4e3ebcb92e1f10L171-R171): Updated the `observation` textarea to handle cases where the `observation` property might be null, preventing potential errors in rendering the view.